### PR TITLE
feat(yahtzee-keybind): add spacebar keybind alternative to button press in yahtzee

### DIFF
--- a/app/frontend/src/modules/yahtzee/components/DiceTable.tsx
+++ b/app/frontend/src/modules/yahtzee/components/DiceTable.tsx
@@ -17,6 +17,33 @@ export default class DiceTable extends React.Component<IProps, {}> {
 	rollIndex: number = 0;
 	lastRollTimeStamp: number | string = -1;
 
+	spaceDownListener: {(event: KeyboardEvent): void};
+
+	constructor(props: IProps) {
+		super(props);
+		this.spaceDownListener = this.onSpaceDownPressed.bind(this);
+	}
+
+	componentDidMount(): void {
+		window.addEventListener('keypress', this.spaceDownListener);
+	}
+
+	componentWillUnmount(): void {
+		window.removeEventListener('keypress', this.spaceDownListener);
+	}
+
+	/**
+	 * attempt to trigger a dice roll, if the active player presses spacebar
+	 * @param event
+	 */
+	onSpaceDownPressed(event: KeyboardEvent): void {
+		console.log(event.key);
+		if (event.key === ' ') {
+			this.onRollRequested();
+		}
+	};
+
+
 	/* Locale Events */
 	onDiceClicked(diceId: number): void {
 		if (!this.props.isLocalPlayerActive) {

--- a/app/frontend/src/modules/yahtzee/components/DiceTable.tsx
+++ b/app/frontend/src/modules/yahtzee/components/DiceTable.tsx
@@ -60,6 +60,7 @@ export default class DiceTable extends React.Component<IProps, {}> {
 		this.setState({});
 	}
 
+	/* The user is trying to roll the dice */
 	onRollRequested(): void {
 		if (!this.props.isLocalPlayerActive) {
 			return;


### PR DESCRIPTION
Implementing requested feature for issue #75 
The game Yahtzee will now listen to the player using spacebar to roll the dices