### PR TITLE
Removing the login requirement for creating new rooms

### DIFF
--- a/app/backend/src/framework/User.ts
+++ b/app/backend/src/framework/User.ts
@@ -294,7 +294,7 @@ export default class User implements IUser {
 	}
 
 	public onCreateNewRoom(): void {
-		if (this.verified && this.currentRoom.getRoomId() === 'lobby') {
+		if (this.currentRoom.getRoomId() === 'lobby') {
 			RoomManager.createRoom(this);
 		}
 	}

--- a/app/frontend/src/framework/components/RoomListBox/RoomListBox.tsx
+++ b/app/frontend/src/framework/components/RoomListBox/RoomListBox.tsx
@@ -108,17 +108,15 @@ export default class RoomListBox extends React.Component<{}, IState> {
 			<div id="roomListBox">
 				{this.state.rooms.map(this.renderRoom.bind(this))}
 
-				{!profileManager.isVerified() ? null : (
-					<div className="room-overview-box room-create-box">
-						<div className="room-overview-box--room-data">Create Room</div>
-						<div
-							className="room-overview-box--member-list"
-							onClick={this.onCreateRoom.bind(this)}
-						>
-							<FontAwesomeIcon icon={['fad', 'plus']} size="3x" />
-						</div>
+				<div className="room-overview-box room-create-box">
+					<div className="room-overview-box--room-data">Create Room</div>
+					<div
+						className="room-overview-box--member-list"
+						onClick={this.onCreateRoom.bind(this)}
+					>
+						<FontAwesomeIcon icon={['fad', 'plus']} size="3x" />
 					</div>
-				)}
+				</div>
 			</div>
 		);
 	}


### PR DESCRIPTION
This PR will allow users to create their own rooms without being logged in.
The reason for this change would be less dependency on the Forum authentication (escpecially while doing maintenance or other changes, like the recent version update), while still keeping some benefits of being logged in:
- Having your own username instead of a randomly generated one
- Having your profile picture instead of a questionmark
- Being allowed to disconnect and then reconnect for a certain amount of time, without being kicked out of the game 